### PR TITLE
Fix 1.8.9 crashing

### DIFF
--- a/MinecraftMod/forge/1.8.9/build.gradle
+++ b/MinecraftMod/forge/1.8.9/build.gradle
@@ -79,7 +79,7 @@ dependencies {
 jar {
     configurations.shade.each { dep ->
         from(project.zipTree(dep)){
-            exclude 'META-INF', 'META-INF/**', 'com/google/gson/**', 'it/unimi/dsi/fastutil/**' // Hacky solution to the extra dependencies being included.
+            exclude 'META-INF', 'META-INF/**'
         }
     }
 }


### PR DESCRIPTION
Include a library that wasn't included back then.