### PR TITLE
Fix Elgato Distribution Tool CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,4 +193,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Stream Deck Plugin
-          path: ./StreamDeckPlugin/*.streamDeckPlugin
+          path: StreamDeckPlugin/*.streamDeckPlugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,8 @@ jobs:
       - name: Run DistributionTool
         uses: AdamCarballo/streamdeck-distribution-tool@v1.0.1
         with:
-          input: './StreamDeckPlugin/com.mosadie.effectmc.sdPlugin'
-          output: './StreamDeckPlugin'
+          input: 'StreamDeckPlugin/com.mosadie.effectmc.sdPlugin'
+          output: 'StreamDeckPlugin'
         
       # Upload Artifact
       - name: Upload Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,4 +193,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Stream Deck Plugin
-          path: StreamDeckPlugin/*.streamDeckPlugin
+          path: StreamDeckPlugin/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,4 +193,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Stream Deck Plugin
-          path: StreamDeckPlugin/*
+          path: ./StreamDeckPlugin/*.streamDeckPlugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,10 +183,10 @@ jobs:
           
       # Run DistributionTool
       - name: Run DistributionTool
-        uses: AdamCarballo/streamdeck-distribution-tool@v1.0.1
+        uses: MoSadie/streamdeck-distribution-tool@4c3ba323c5ad7ef45acb772e1f4833468ce204fa
         with:
-          input: 'StreamDeckPlugin/com.mosadie.effectmc.sdPlugin'
-          output: 'StreamDeckPlugin'
+          input: 'com.mosadie.effectmc.sdPlugin'
+          working-directory: 'StreamDeckPlugin'
         
       # Upload Artifact
       - name: Upload Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,24 +180,13 @@ jobs:
       - name: Generate Stream Deck Plugin
         working-directory: ./StreamDeckPlugin
         run: './gradlew.bat run --no-daemon'
-
-      # Download DistributionTool from Elgato
-      - name: Download DistributionTool
-        uses: carlosperate/download-file-action@v1.0.3
-        with:
-          file-url: 'https://developer.elgato.com/documentation/stream-deck/distributiontool/DistributionToolWindows.zip'
-        
-      # Unzip DistributionTool
-      - name: Unzip DistributionTool
-        uses: DuckSoft/extract-7z-action@v1.0
-        with:
-          pathSource: './DistributionToolWindows.zip'
-          pathTarget: './StreamDeckPlugin'
           
       # Run DistributionTool
       - name: Run DistributionTool
-        working-directory: './StreamDeckPlugin'
-        run: './DistributionTool.exe -b -i com.mosadie.effectmc.sdPlugin -o .'
+        uses: AdamCarballo/streamdeck-distribution-tool@v1.0.1
+        with:
+          input: './StreamDeckPlugin/com.mosadie.effectmc.sdPlugin'
+          output: './StreamDeckPlugin'
         
       # Upload Artifact
       - name: Upload Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           
       # Run DistributionTool
       - name: Run DistributionTool
-        uses: MoSadie/streamdeck-distribution-tool@4c3ba323c5ad7ef45acb772e1f4833468ce204fa
+        uses: MoSadie/streamdeck-distribution-tool@22472fe2a1ae677822b11328d0df0f98dc7febab
         with:
           input: 'com.mosadie.effectmc.sdPlugin'
           working-directory: 'StreamDeckPlugin'


### PR DESCRIPTION
Closes #34.

TBH this solution is a bit hacky, but it does work, which is better than before.